### PR TITLE
Tim's Pull Request to properly display medic icons in the Roster Views.

### DIFF
--- a/app/static/js/webstaff.js
+++ b/app/static/js/webstaff.js
@@ -206,8 +206,8 @@ Copyright 2017 Joseph Porcelli
             // case Attendant
             case 'attendant':
             case 'attendant a':
-            case 'attandant b':
-                return 'attandant';
+            case 'attendant b':
+                return 'attendant';
                 break;
 
             // Generic officer


### PR DESCRIPTION
Fixed a typo that caused medics to show as firefighters.

Hopefully, this is the right way to do this.  Perhaps we should have a conversation about your preference.