### PR TITLE
  Add Docker image and Compose stack for the dashboard

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,41 @@
+# Git and VCS
+.git
+.gitignore
+*.md
+!README.md
+
+# Python
+__pycache__
+*.py[cod]
+*$py.class
+.pytest_cache
+.mypy_cache
+.ruff_cache
+*.egg-info
+.eggs
+dist
+build
+venv
+.env
+.env.*
+!.env.example
+
+# IDE / OS
+.idea
+.vscode
+.DS_Store
+
+# Logs and local DB (mount a volume for persistent data instead)
+log
+*.db
+instance
+
+# Tests / coverage
+.coverage
+htmlcov
+.tox
+
+# Docker
+Dockerfile*
+docker-compose*.yml
+.dockerignore

--- a/.env.example
+++ b/.env.example
@@ -11,8 +11,19 @@ SECRET_KEY="This is a secret key for the dashboard"
 # true = debug server, ephemeral SECRET_KEY allowed if SECRET_KEY unset
 DASHBOARD_DEBUG=true
 
+# Bind address/port for local `python afddashboard.py` (not Docker; see README Docker).
 DASHBOARD_HOST=127.0.0.1
 DASHBOARD_PORT=5000
+
+# --- Docker Compose (substitution in docker-compose.yml; also see env_file on the service) ---
+# Published host port -> container 5000. Inside the container, Gunicorn always uses 5000.
+HOST_PORT=8000
+
+# Optional: tag/name for `docker compose build` / `image:` (default below).
+# COMPOSE_IMAGE=afd-dashboard:local
+
+# Optional: Compose restart policy (no | always | on-failure | unless-stopped).
+# DOCKER_RESTART=unless-stopped
 
 # Required when DASHBOARD_DEBUG is false
 ADMIN_USERNAME=
@@ -33,7 +44,8 @@ TS_COOKIE=
 MAPBOX_ACCESS_TOKEN=
 
 # Optional
-# DATABASE_URL=sqlite:///path/to/app.db
+# DATABASE_URL — local dev: sqlite:///path/to/app.db | Docker: sqlite:////data/app.db (compose default) or Postgres URL
 # ASYNC_MODE=threading
 # LOGGING_PATH=log
 # LOGGING_LEVEL=20   # INFO; default in code is 1 if unset
+# GUNICORN_THREADS=20   # gthread worker pool (Docker / production)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,47 @@
+# AFD Dashboard — Flask + Flask-SocketIO + Active911 client thread
+# Build: docker build -t afd-dashboard .
+# Run:  see docker-compose.yml or pass env vars (-e SECRET_KEY=... etc.)
+
+FROM python:3.12-slim-bookworm
+
+# Quieter pip during image build (install runs as root in this stage)
+ENV PIP_ROOT_USER_ACTION=ignore
+
+# git: required for pip install from git URLs in requirements.txt
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends git \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Layer cache: dependencies before application code
+# VCS deps: install PyPI lines first, then git URLs with --no-build-isolation so
+# a911client can import slixmpp during metadata. Non-isolated builds still invoke
+# PEP 517 backends (setuptools.build_meta, flit_core.buildapi); slim images do not
+# always ship those, so install them explicitly before the git installs.
+COPY requirements.txt .
+RUN pip install --no-cache-dir --upgrade pip \
+    && sed '/^git+/d' requirements.txt > /tmp/requirements-pypi.txt \
+    && pip install --no-cache-dir -r /tmp/requirements-pypi.txt \
+    && pip install --no-cache-dir setuptools wheel flit-core \
+    && grep '^git+' requirements.txt | xargs -r -I {} pip install --no-cache-dir --no-build-isolation {} \
+    && rm -f /tmp/requirements-pypi.txt
+
+COPY . .
+
+RUN mkdir -p /data \
+    && chmod +x docker-entrypoint.sh \
+    && useradd --create-home --uid 1000 appuser \
+    && chown -R appuser:appuser /app /data
+
+USER appuser
+
+ENV PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    FLASK_APP=app:create_app
+
+EXPOSE 5000
+
+ENTRYPOINT ["./docker-entrypoint.sh"]
+# Gunicorn gthread: matches Flask-SocketIO async_mode=threading; -w 1 required for Socket.IO
+CMD ["sh", "-c", "exec gunicorn -k gthread -w 1 --threads ${GUNICORN_THREADS:-20} --bind 0.0.0.0:${DASHBOARD_PORT:-5000} --access-logfile - --error-logfile - wsgi:app"]

--- a/README.md
+++ b/README.md
@@ -70,6 +70,36 @@ Next, you will want to launch the server:
 $ python test_app.py
 ```
 
+### Docker
+
+Build and run with [Docker Compose](https://docs.docker.com/compose/) (see `docker-compose.yml`):
+
+```bash
+cp .env.example .env   # edit: secrets, ACTIVE_911_DEVICE_ID, etc.
+docker compose build
+docker compose up
+```
+
+The image runs `flask db upgrade` on startup, then **Gunicorn** (`gthread` worker, `wsgi:app`) on **port 5000 inside the container**. Compose maps **`HOST_PORT` → 5000** (default **8000** when unset; see `.env.example`). Optional compose-only knobs: **`COMPOSE_IMAGE`**, **`DOCKER_RESTART`**. Do not rely on `DASHBOARD_PORT` in `.env` for Docker: that value is for local `python afddashboard.py` only — if it matched your public port (e.g. 8000), Gunicorn would listen on the wrong port inside the container and the browser would see **ERR_CONNECTION_RESET**.
+
+SQLite is stored on the `dashboard-data` volume at `/data/app.db` when `DATABASE_URL` defaults to `sqlite:////data/app.db`. Override `DATABASE_URL` for PostgreSQL or another backend. Locally you can still run `python afddashboard.py` (also Gunicorn).
+
+`docker-compose.yml` sets `DASHBOARD_DEBUG` to `true` by default so `SECRET_KEY` is not required for local runs (the app generates an ephemeral key). For production, set `DASHBOARD_DEBUG=false` and provide `SECRET_KEY`, `ADMIN_USERNAME`, and `ADMIN_PASSWORD` in `.env`.
+
+Compose reads a project `.env` for `${VAR}` substitution in the YAML. **`docker compose --env-file .env` does not inject that file into containers by itself** — the compose file uses `env_file: .env` on the service so variables like `SECRET_KEY` and `ACTIVE_911_DEVICE_ID` reach the app. Use a `.env` next to `docker-compose.yml` (or adjust `env_file` / use `environment:` explicitly).
+
+For a one-off build without Compose: `docker build -t afd-dashboard .` then `docker run --rm -p 5000:5000 -e DASHBOARD_DEBUG=true ... afd-dashboard`.
+
+If `pip install -r requirements.txt` fails on the `git+https://…` lines, install PyPI packages first, then PEP 517 backends (needed for `--no-build-isolation` git installs on minimal environments), then VCS URLs:
+
+```bash
+sed '/^git+/d' requirements.txt > /tmp/req-pypi.txt && pip install -r /tmp/req-pypi.txt
+pip install setuptools wheel flit-core
+grep '^git+' requirements.txt | xargs -I {} pip install --no-build-isolation {}
+```
+
+**Docker build and GitHub:** The image must clone `git+https://github.com/...` dependencies during `docker build`. If you see `Could not resolve host: github.com` (or similar), the build environment has no working DNS or outbound HTTPS. Fix network/DNS on the host (Docker Desktop → Settings → network/DNS, VPN split-tunnel, corporate proxy). On Linux, `docker build --network=host -t afd-dashboard .` sometimes helps when bridge DNS is broken. Air-gapped builds need wheels or vendored copies of those packages instead of live `git clone`.
+
 
 ## Using the Dashboard
 

--- a/afddashboard.py
+++ b/afddashboard.py
@@ -2,40 +2,47 @@
 # -*- coding: ascii -*-
 
 """
-A Production harness for AFD Dashboard
+Run the dashboard with Gunicorn (gthread worker; matches Flask-SocketIO threading).
 
-Requires port 80 is open
-
-Changelog:
-    - 2018-05-15 - Initial Commit
+Dockerfile invokes Gunicorn directly; this module is for local ``python afddashboard.py``.
 """
 
-import threading
-from app import create_app, db, socketio
-from app.models import Alert, Roster, Station, Unit
-from app.active911.client import start_active911_client
+import os
+import sys
+
 from config import Config
 
-# If we're using eventlet middleware (WSGI) we want to monkey patch
-# all of our sockets, connections, and threads
-# try:
-#     import eventlet
-#     eventlet.monkey_patch()
-# except ImportError:
-#     pass    # Default to Werkzeug/Threading, so we don't have to do anything
 
-app = create_app()
+def main():
+    bind = f"{Config.DASHBOARD_HOST}:{Config.DASHBOARD_PORT}"
+    threads = str(Config.GUNICORN_THREADS)
 
-if __name__ == '__main__':
-    # Run the socketIO Stuff here
+    args = [
+        sys.executable,
+        "-m",
+        "gunicorn",
+    ]
+    if Config.DASHBOARD_DEBUG:
+        args.append("--reload")
+    args.extend(
+        [
+            "-k",
+            "gthread",
+            "-w",
+            "1",
+            "--threads",
+            threads,
+            "--bind",
+            bind,
+            "--access-logfile",
+            "-",
+            "--error-logfile",
+            "-",
+            "wsgi:app",
+        ]
+    )
+    os.execvp(sys.executable, args)
 
-    print(app.config['ACTIVE_911_DEVICE_ID'])
-    
-    a911_client_thread = threading.Thread(target=start_active911_client, args=(app,))
-    a911_client_thread.daemon = True
-    a911_client_thread.start()
 
-    socketio.run(app=app, \
-                 host=Config.DASHBOARD_HOST, \
-                 port=Config.DASHBOARD_PORT, \
-                 debug=Config.DASHBOARD_DEBUG)
+if __name__ == "__main__":
+    main()

--- a/config.py
+++ b/config.py
@@ -70,6 +70,12 @@ class Config(object):
 
     DASHBOARD_PORT = int(os.environ.get("DASHBOARD_PORT", "5000"))
 
+    # Gunicorn gthread worker (see wsgi.py / afddashboard.py). Single worker (-w 1) for Socket.IO.
+    GUNICORN_THREADS = int(os.environ.get("GUNICORN_THREADS", "20"))
+
+    # Flask expects DEBUG for app.debug (templates, tracebacks).
+    DEBUG = DASHBOARD_DEBUG
+
     LOGGING_PATH = os.environ.get("LOGGING_PATH") or "log"
 
     # Standard logging module levels (e.g. 20 = INFO, 1 = very verbose legacy default).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,35 @@
+# Example stack. Copy .env.example to .env and set secrets.
+# Production: DASHBOARD_DEBUG=false, SECRET_KEY, ADMIN_USERNAME, ADMIN_PASSWORD,
+# ACTIVE_911_DEVICE_ID.
+#
+# SQLite is stored under /data (named volume). Override DATABASE_URL for PostgreSQL, etc.
+#
+# `docker compose --env-file .env` only affects ${VAR} substitution in THIS file.
+# To pass variables into the container, we use `env_file` below (Compose also loads
+# project `.env` for interpolation by default).
+
+services:
+  dashboard:
+    build: .
+    image: ${COMPOSE_IMAGE:-afd-dashboard:local}
+    # Host port (e.g. 8000) -> container 5000. Do not reuse DASHBOARD_PORT here: .env
+    # often sets DASHBOARD_PORT for local `python afddashboard.py`; that must not change
+    # the port Gunicorn listens on inside the container (always 5000; see environment).
+    ports:
+      - "${HOST_PORT:-8000}:5000"
+    env_file:
+      - path: .env
+        required: false
+    environment:
+      # Override .env so the app listens on all interfaces and on container port 5000.
+      DASHBOARD_HOST: "0.0.0.0"
+      DASHBOARD_PORT: "5000"
+      DATABASE_URL: "${DATABASE_URL:-sqlite:////data/app.db}"
+      # When unset in .env / host, keep local `compose up` working without SECRET_KEY.
+      DASHBOARD_DEBUG: "${DASHBOARD_DEBUG:-true}"
+    volumes:
+      - dashboard-data:/data
+    restart: ${DOCKER_RESTART:-unless-stopped}
+
+volumes:
+  dashboard-data:

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+set -e
+# Apply Alembic migrations when the app starts (idempotent).
+flask db upgrade
+exec "$@"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 # Core Flask and web framework dependencies
 Flask>=2.3.3
+gunicorn>=22.0.0
 python-dotenv>=1.0.0
 
 Flask-Mail>=0.9.1
@@ -54,6 +55,10 @@ pytest-cov>=4.1.0
 black>=24.1.1
 isort>=5.13.2
 mypy>=1.8.0
+
+# Runtime dep for a911client (XMPP). Docker/README use --no-build-isolation for git lines.
+slixmpp>=1.8.0
+
 git+https://github.com/porcej/a911client.git
 git+https://github.com/porcej/festis.git
 git+https://github.com/maxcountryman/flask-login.git

--- a/wsgi.py
+++ b/wsgi.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python
+# -*- coding: ascii -*-
+"""
+WSGI entry for Gunicorn.
+
+Flask-SocketIO with async_mode=threading is served with ``gthread`` workers
+(see afddashboard.py / Dockerfile). Use a single worker (-w 1) for Socket.IO.
+
+Active911 runs in a daemon thread started once per process (see below).
+"""
+
+import threading
+
+from app import create_app
+from app.active911.client import start_active911_client
+
+app = create_app()
+
+_active911_lock = threading.Lock()
+_active911_started = False
+
+
+def _start_active911_once():
+    global _active911_started
+    with _active911_lock:
+        if _active911_started:
+            return
+        _active911_started = True
+        t = threading.Thread(target=start_active911_client, args=(app,))
+        t.daemon = True
+        t.start()
+
+
+_start_active911_once()


### PR DESCRIPTION
- Dockerfile: Python 3.12 slim, git for pip VCS deps, non-root user, /data for SQLite, entrypoint runs  then
- docker-compose.yml: port mapping, persistent volume for /data, default DATABASE_URL to sqlite:////data/app.db
- .dockerignore to exclude secrets, local DB, logs, and venv from the build context
- README: Docker/Compose usage and SQLite volume note

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes how the app is started in both Docker and local runs (Gunicorn + entrypoint migrations) and introduces a new WSGI entrypoint that starts the Active911 background thread, which can affect runtime behavior and deployment reliability.
> 
> **Overview**
> Adds first-class Docker support: a new `Dockerfile`, `docker-compose.yml`, `.dockerignore`, and `docker-entrypoint.sh` to build/run the dashboard as a non-root container, run `flask db upgrade` on startup, persist SQLite under `/data`, and expose the app via Gunicorn (`gthread`, single worker) with configurable host port mapping.
> 
> Updates runtime wiring to match the container model: `afddashboard.py` now launches Gunicorn instead of `socketio.run`, `wsgi.py` is introduced as the Gunicorn entrypoint and starts the Active911 client thread once per process, and `config.py` gains `GUNICORN_THREADS` plus `DEBUG` derived from `DASHBOARD_DEBUG`. Documentation and `.env.example` are expanded with Compose/Docker-specific environment guidance, and `requirements.txt` adds `gunicorn` and `slixmpp` to support these changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5391e32a873d42d9d40cc57528e31fc798f3322e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->