### PR TITLE
feat(telestaff): DB settings, scheduled roster fetch, snapshot API, w…

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -123,7 +123,9 @@ def create_app(config_class=Config):
     from app.admin import bp as admin_bp
     app.register_blueprint(admin_bp)
 
-    # scheduler.start()
+    from app.telestaff.scheduler import init_telestaff_scheduler
+
+    init_telestaff_scheduler(app)
 
     # Now check if we are debug/testing if not load logging
     if not app.debug and not app.testing:

--- a/app/admin/routes.py
+++ b/app/admin/routes.py
@@ -14,10 +14,19 @@ __version__ = "0.0.1"
 __copyright__ = "Copyright (c) 2018 Joseph Porcelli"
 __license__ = "MIT"
 
-from flask import render_template, current_app, request, jsonify
+import json
+
+from flask import render_template, current_app, request, jsonify, flash, redirect, url_for
 from flask_login import current_user, login_required
 from app.admin import bp
 from app.models import Alert, Station, Unit
+from app.telestaff.routes import telestaff_roster_payload
+from app.telestaff.settings_store import (
+    effective_server as telestaff_effective_server,
+    get_settings_row,
+    save_admin_settings,
+    save_schedule_settings,
+)
 from app import db, socketio
 from sqlalchemy import exc
 
@@ -35,6 +44,82 @@ def admin():
     """
     stations = Station.query.order_by(Station.name.asc()).all()
     return render_template('admin/admin.html', stations=stations)
+
+def _roster_fetch_error_message(err_response):
+    """Build a short message from a roster error (jsonify tuple response)."""
+    resp, _status = err_response
+    data = resp.get_json(silent=True) or {}
+    parts = [data.get("error"), data.get("hint")]
+    return ": ".join(p for p in parts if p) or "Roster fetch failed."
+
+
+@bp.route('/admin/telestaff', methods=['GET', 'POST'])
+@bp.route('/admin/telestaff/', methods=['GET', 'POST'])
+@login_required
+def telestaff_settings():
+    """
+    Configure Telestaff base URL and cookie header stored in the database.
+    Empty fields fall back to TS_SERVER / TS_COOKIE from the environment.
+    """
+    stations = Station.query.order_by(Station.name.asc()).all()
+    if request.method == 'POST':
+        action = request.form.get('action', 'save')
+        if action == 'fetch_roster':
+            _payload, err = telestaff_roster_payload(date=None)
+            if err is not None:
+                flash('Error: ' + _roster_fetch_error_message(err))
+            else:
+                flash('Roster fetched; snapshot saved.')
+            return redirect(url_for('admin.telestaff_settings'))
+        if action == 'save_schedule':
+            enabled = request.form.get('roster_scheduler_enabled') == 'on'
+            minutes = request.form.get('roster_fetch_interval_minutes', type=int)
+            save_schedule_settings(enabled, minutes, current_app)
+            flash('Roster schedule saved.')
+            return redirect(url_for('admin.telestaff_settings'))
+        server_url = request.form.get('server_url', '') or ''
+        cookie_header = request.form.get('cookie_header', '') or ''
+        save_admin_settings(server_url, cookie_header)
+        flash('Telestaff settings saved.')
+        return redirect(url_for('admin.telestaff_settings'))
+    row = get_settings_row()
+    interval_minutes = 15
+    if row and row.roster_fetch_interval_seconds:
+        interval_minutes = max(1, row.roster_fetch_interval_seconds // 60)
+    return render_template(
+        'admin/telestaff_settings.html',
+        stations=stations,
+        row=row,
+        env_server=(current_app.config.get('TS_SERVER') or '').strip(),
+        effective_server=telestaff_effective_server(current_app),
+        interval_minutes=interval_minutes,
+    )
+
+
+@bp.route('/admin/telestaff/roster-json', methods=['GET'])
+@bp.route('/admin/telestaff/roster-json/', methods=['GET'])
+@login_required
+def telestaff_roster_json():
+    """Pretty-printed JSON of the last stored roster response (admin only)."""
+    stations = Station.query.order_by(Station.name.asc()).all()
+    row = get_settings_row()
+    raw = row.last_roster_json if row else None
+    if not raw:
+        pretty_json = None
+    else:
+        try:
+            pretty_json = json.dumps(
+                json.loads(raw), indent=2, sort_keys=True, default=str
+            )
+        except (TypeError, ValueError):
+            pretty_json = raw
+    return render_template(
+        'admin/telestaff_roster_json.html',
+        stations=stations,
+        pretty_json=pretty_json,
+        last_fetch=row.last_roster_fetched_at if row else None,
+    )
+
 
 @bp.route('/admin/console')
 @bp.route('/admin/console/')

--- a/app/models.py
+++ b/app/models.py
@@ -61,6 +61,22 @@ class Unit(db.Model):
     alert_id = db.Column(db.Integer, db.ForeignKey('station.id'))
 
     def __repr__(self):
-        return '<Unit {}: Home: {}, MovedUp: {}'.format(self.name, \
-                                                        self.home.name,\
-                                                        self.movedup.name)
+        return '<Unit {}>'.format(self.name)
+
+
+class TelestaffSettings(db.Model):
+    """Singleton (id=1): optional override for Telestaff host URL and cookie header."""
+
+    __tablename__ = "telestaff_settings"
+
+    id = db.Column(db.Integer, primary_key=True)
+    server_url = db.Column(db.String(512), nullable=True)
+    cookie_header = db.Column(db.Text(), nullable=True)
+    updated_at = db.Column(db.DateTime(), nullable=True)
+    last_roster_fetched_at = db.Column(db.DateTime(), nullable=True)
+    last_roster_json = db.Column(db.Text(), nullable=True)
+    roster_scheduler_enabled = db.Column(db.Boolean(), nullable=False, default=False)
+    roster_fetch_interval_seconds = db.Column(db.Integer(), nullable=False, default=900)
+
+    def __repr__(self):
+        return '<TelestaffSettings id={}>'.format(self.id)

--- a/app/static/js/webstaff.js
+++ b/app/static/js/webstaff.js
@@ -13,16 +13,18 @@ Copyright 2017 Joseph Porcelli
     'use strict';
 
     var ws_settings = {
-            url                 : '/roster/',           // Where to get data '' is same domain
+            // Cached roster JSON from server-side scheduled fetches (no Telestaff call per poll).
+            url                 : '/roster/snapshot/',
             targetElement       : ".cb-webstaff",       // Target HTML Element
             alertElement        : ".cb-webstaff-alert", // Target Element for HTML Alerts
             rosterElement       : ".cb-webstaff-roster",// Target element Roster
             timer               : null,                 // Var to hold timer to check for updates
+            // Poll snapshot often; Telestaff is updated on the server schedule only.
+            updateResolution    : 60000,                // ms between snapshot reloads (60 s)
             // updateResolution    : 30000,
-            updateResolution    : 900000,               // # of ms between time updates
+            // updateResolution    : 900000,
             // updateResolution: 500,
-            // updateResolution: 60000,                 // # of ms between time updates
-                                                        //    900000 -> 15 min
+                                                        //    900000 -> 15 min (legacy live /roster)
             rollOverTime        : "2400",               // Time of day to show
                                                         // next day's roster HHmm
                                                         // Note that setting this to 0000
@@ -144,6 +146,35 @@ Copyright 2017 Joseph Porcelli
         return '';
         
     }   // getShift()
+
+
+    /* =========================================================================
+     * Telestaff roster shift titles: legacy "Ops A Shift" vs newer "4 Ops Shifts A".
+     * When getShift() is empty (calendar no longer matches 2017 cycle), callers skip
+     * shift-level filtering and rely on station/unit filters only.
+     * ====================================================================== */
+    function shiftMatchesShiftTitle(shiftTitle, shiftLetter, rosterDateStr) {
+        if (!shiftTitle) {
+            return false;
+        }
+        if (rosterDateStr && shiftTitle === rosterDateStr) {
+            return true;
+        }
+        var m = shiftTitle.match(/Shifts?\s+([ABC])\b/i);
+        if (m && shiftLetter) {
+            return m[1].toUpperCase() === shiftLetter.toUpperCase();
+        }
+        if (shiftLetter) {
+            var t = shiftTitle.toUpperCase();
+            var letter = shiftLetter.toUpperCase();
+            if (t.indexOf('OPS') >= 0) {
+                if (t.indexOf('SHIFTS ' + letter) >= 0 || t.indexOf('SHIFT ' + letter) >= 0) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
 
 
     /* =========================================================================
@@ -501,13 +532,13 @@ Copyright 2017 Joseph Porcelli
 
         $.ajax({
             type : 'GET',
-            url  : ws_settings.url + date.format('YYYYMMDD'),
+            url  : ws_settings.url,
             dataType : 'json',
             success: function(json, textStatus, request){
                 $(ws_settings.alertElement).remove();
                 console.log("Telestaff data received at " + moment().format('D MMM, YYYY - HH:mm:ss') + ".");
-                if (json.status_code.toString() == '200' ){
-                    if (json.data.type == 'roster'){
+                if (String(json.status_code) === '200' ){
+                    if (json.data && json.data.type == 'roster'){
 
                         var saveThis = function(title){
                             if (!title){
@@ -527,72 +558,80 @@ Copyright 2017 Joseph Porcelli
                         var singleUnit = [];
                         var multipleUnits = [];
 
-                        var rosterDate;
-
-
                         for (var ddx=0; ddx < json.data.Date.length; ddx++){
-                                var tempDate = json.data.Date[ddx].title;
-                                rosterDate = moment(tempDate.substr(tempDate.indexOf(',') + 1).trim(), "MMMM DD, YYYY");
-                                rosterDate = "Ops " + getShift(rosterDate).toUpperCase() + " Shift";
-                            if (saveThis(json.data.Date[ddx].title)){
-                                if (json.data.Date[ddx].hasOwnProperty('Position')){
-                                    singleUnit.push(json.data.Date[ddx]);
+                            var dateEntry = json.data.Date[ddx];
+                            var tempDate = dateEntry.title || '';
+                            var rosterMoment = moment(tempDate.substr(tempDate.indexOf(',') + 1).trim(), "MMMM DD, YYYY");
+                            var shiftLetter = getShift(rosterMoment) || '';
+                            var rosterDateStr = shiftLetter
+                                ? ('Ops ' + shiftLetter.toUpperCase() + ' Shift')
+                                : '';
+
+                            if (saveThis(dateEntry.title)){
+                                if (dateEntry.hasOwnProperty('Position')){
+                                    singleUnit.push(dateEntry);
                                 } else {
-                                    multipleUnits.push(json.data.Date[ddx]);
+                                    multipleUnits.push(dateEntry);
                                 }
                             } else {
-                                var batallions = json.data.Date[ddx].Institution[0].Agency[0].Batallion;
+                                var institutions = dateEntry.Institution || [];
+                                for (var idx = 0; idx < institutions.length; idx++) {
+                                    var agencies = institutions[idx].Agency || [];
+                                    for (var agx = 0; agx < agencies.length; agx++) {
+                                        var batallions = agencies[agx].Batallion || [];
 
-                                for (var bdx=0; bdx < batallions.length; bdx++){
-                                    if (saveThis(batallions[bdx].title)){
-                                       if (batallions[bdx].hasOwnProperty('Position')){
-                                            singleUnit.push(batallions[bdx]);
-                                        } else {
-                                            multipleUnits.push(batallions[bdx]);
-                                        }
-                                    } else {
-                                        var shifts = batallions[bdx].Shift;
-                                        for (var shiftDx = 0; shiftDx < shifts.length; shiftDx++){
-                                            if (shifts[shiftDx].title !== rosterDate){
-                                                continue;
-                                            }
-
-                                            if ( saveThis( shifts[shiftDx].title )){
-
-                                               if (shifts[shiftDx].hasOwnProperty('Position')){
-                                                    singleUnit.push(shifts[shiftDx]);
+                                        for (var bdx=0; bdx < batallions.length; bdx++){
+                                            if (saveThis(batallions[bdx].title)){
+                                                if (batallions[bdx].hasOwnProperty('Position')){
+                                                    singleUnit.push(batallions[bdx]);
                                                 } else {
-                                                    multipleUnits.push(shifts[shiftDx]);
+                                                    multipleUnits.push(batallions[bdx]);
                                                 }
                                             } else {
-                                                var stations = shifts[shiftDx].Station;
-                                                for (var sdx=0; sdx < stations.length; sdx++){
-                                                    if ( saveThis( stations[sdx].title )){
-                                                       if (stations[sdx].hasOwnProperty('Position')){
-                                                            singleUnit.push(stations[sdx]);
+                                                var shifts = batallions[bdx].Shift || [];
+                                                for (var shiftDx = 0; shiftDx < shifts.length; shiftDx++){
+                                                    if (shiftLetter) {
+                                                        if (!shiftMatchesShiftTitle(shifts[shiftDx].title, shiftLetter, rosterDateStr)){
+                                                            continue;
+                                                        }
+                                                    }
+
+                                                    if ( saveThis( shifts[shiftDx].title )){
+
+                                                        if (shifts[shiftDx].hasOwnProperty('Position')){
+                                                            singleUnit.push(shifts[shiftDx]);
                                                         } else {
-                                                            multipleUnits.push(stations[sdx]);
+                                                            multipleUnits.push(shifts[shiftDx]);
                                                         }
                                                     } else {
-                                                        var units = stations[sdx].Unit;
-                                                        for (var udx=0; udx < units.length;udx++){
-                                                            if( saveThis( units[udx].title ) ){
-                                                               if (units[udx].hasOwnProperty('Position')){
-                                                                    singleUnit.push(units[udx]);
+                                                        var stations = shifts[shiftDx].Station || [];
+                                                        for (var sdx=0; sdx < stations.length; sdx++){
+                                                            if ( saveThis( stations[sdx].title )){
+                                                                if (stations[sdx].hasOwnProperty('Position')){
+                                                                    singleUnit.push(stations[sdx]);
                                                                 } else {
-                                                                    multipleUnits.push(units[udx]);
+                                                                    multipleUnits.push(stations[sdx]);
                                                                 }
+                                                            } else {
+                                                                var units = stations[sdx].Unit || [];
+                                                                for (var udx=0; udx < units.length; udx++){
+                                                                    if( saveThis( units[udx].title ) ){
+                                                                        if (units[udx].hasOwnProperty('Position')){
+                                                                            singleUnit.push(units[udx]);
+                                                                        } else {
+                                                                            multipleUnits.push(units[udx]);
+                                                                        }
+                                                                    }
+                                                                }
+
                                                             }
                                                         }
-
                                                     }
                                                 }
                                             }
                                         }
                                     }
                                 }
-
-
                             }
 
                         }   // End Unit Filtering
@@ -608,7 +647,7 @@ Copyright 2017 Joseph Porcelli
                         for (var sdx=0; sdx < multipleUnits.length; sdx++ ){
                             if (! multipleUnits[sdx].dot){
                                 
-                                var units = multipleUnits[sdx].Unit;
+                                var units = multipleUnits[sdx].Unit || [];
                                 for (var udx=0; udx < units.length; udx++ ){
                                     if (!units[udx].dot){
                                         var unitHeader = '<div class="card-header clearfix">' + units[udx].title;
@@ -620,7 +659,7 @@ Copyright 2017 Joseph Porcelli
                                         var unitDiv = $('<div/>').addClass("card mb-4 cb-unit-roster cb-" + getUnitType(units[udx].title));
                                         unitDiv.append(unitHeader);
 
-                                        var positions = units[udx].Position;
+                                        var positions = units[udx].Position || [];
                                         // var positionsDiv = $('<div/>').addClass('card-block');
                                         var positionsDiv = $('<table/>').addClass('unit-positions');
 
@@ -674,7 +713,7 @@ Copyright 2017 Joseph Porcelli
                                 var unitDiv = $('<div/>').addClass("card mb-4 cb-unit-roster cb-" + getUnitType(unit.title));
                                     unitDiv.append(unitHeader);
 
-                                var positions = unit.Position;
+                                var positions = unit.Position || [];
 
                                 var positionsDiv = $('<table/>').addClass('unit-positions');
 

--- a/app/telestaff/routes.py
+++ b/app/telestaff/routes.py
@@ -13,14 +13,18 @@ __version__ = "0.0.1"
 __copyright__ = "Copyright (c) 2018 Joseph Porcelli"
 __license__ = "MIT"
 
+import json
+
 from festis import telestaff as ts
 from flask import current_app, jsonify
 from app.telestaff import bp
-
-
-def _telestaff_base_url():
-    raw = (current_app.config.get("TS_SERVER") or "").strip()
-    return raw
+from app.telestaff.settings_store import (
+    effective_cookie,
+    effective_server,
+    get_settings_row,
+    persist_last_roster_snapshot,
+    persist_telestaff_cookies,
+)
 
 
 def _sanitize_telestaff_payload(obj):
@@ -58,45 +62,98 @@ def _telestaff_login_config_error():
     return None
 
 
-# *====================================================================*
-#         Routes
-# *====================================================================*
+def telestaff_roster_payload(date=None):
+    """
+    Perform Telestaff roster fetch and persist cookies + last roster snapshot.
 
-@bp.route('/roster')
-@bp.route('/roster/')
-@bp.route('/roster/<date>')
-def roster(date=None):
-    base = _telestaff_base_url()
+    Returns:
+        (payload_dict, None) on success
+        (None, (response, status_code)) on error (suitable as Flask return value)
+    """
+    base = effective_server(current_app)
     if not base:
-        return jsonify(
-            error="TS_SERVER is not set",
-            hint="Set TS_SERVER in the environment (e.g. https://telestaff.example.gov)",
-        ), 503
+        return None, (
+            jsonify(
+                error="TS_SERVER is not set",
+                hint=(
+                    "Set TS_SERVER in the environment or configure the Telestaff URL "
+                    "in Admin / Telestaff."
+                ),
+            ),
+            503,
+        )
     if not (base.startswith("http://") or base.startswith("https://")):
-        return jsonify(
-            error="TS_SERVER must start with http:// or https://",
-            hint=base[:80] + ("..." if len(base) > 80 else ""),
-        ), 400
+        return None, (
+            jsonify(
+                error="TS_SERVER must start with http:// or https://",
+                hint=base[:80] + ("..." if len(base) > 80 else ""),
+            ),
+            400,
+        )
 
     login_err = _telestaff_login_config_error()
     if login_err is not None:
-        return login_err
+        return None, login_err
 
     cfg = current_app.config
     telestaff = ts.Telestaff(
         host=base,
         t_user=(cfg.get("TS_USER") or "").strip(),
         t_pass=cfg.get("TS_PASS"),
-        cookies=cfg.get("TS_COOKIE") or "",
+        cookies=effective_cookie(current_app) or "",
     )
 
-    telestaff.do_login()
     response = telestaff.get_telestaff(kind="rosterFull", date=date)
-    if not isinstance(response, dict):
-        return jsonify(data=_sanitize_telestaff_payload(response))
+    cookies_dict = telestaff.get_cookies()
+    if cookies_dict:
+        cookie_string = "; ".join(f"{k}={v}" for k, v in cookies_dict.items())
+        persist_telestaff_cookies(cookie_string)
+        cfg["TS_COOKIE"] = cookie_string
 
-    out = {
-        "status_code": response.get("status_code"),
-        "data": _sanitize_telestaff_payload(response.get("data")),
-    }
+    if not isinstance(response, dict):
+        out = {"data": _sanitize_telestaff_payload(response)}
+    else:
+        out = {
+            "status_code": response.get("status_code"),
+            "data": _sanitize_telestaff_payload(response.get("data")),
+        }
+
+    persist_last_roster_snapshot(out)
+    return out, None
+
+
+# *====================================================================*
+#         Routes
+# *====================================================================*
+
+@bp.route('/roster/snapshot')
+@bp.route('/roster/snapshot/')
+def roster_snapshot():
+    """
+    Return the last stored roster JSON (no Telestaff call).
+    Dashboards poll this to refresh the display after server-side scheduled fetches.
+    """
+    row = get_settings_row()
+    if row is None or not row.last_roster_json:
+        return jsonify(
+            error="No roster snapshot yet",
+            hint=(
+                "Enable the scheduled fetch or use Fetch latest roster in Admin / Telestaff, "
+                "or call GET /roster once."
+            ),
+        ), 503
+    try:
+        payload = json.loads(row.last_roster_json)
+    except (TypeError, ValueError):
+        return jsonify(error="Stored roster snapshot is invalid JSON."), 500
+    return jsonify(payload)
+
+
+@bp.route('/roster')
+@bp.route('/roster/')
+@bp.route('/roster/<date>')
+def roster(date=None):
+    out, err = telestaff_roster_payload(date=date)
+    if err is not None:
+        return err
     return jsonify(out)

--- a/app/telestaff/scheduler.py
+++ b/app/telestaff/scheduler.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python
+# -*- coding: ascii -*-
+
+"""
+Background interval job to fetch Telestaff roster (APScheduler).
+
+Only one process runs the scheduler when a Unix file lock can be acquired
+(see Gunicorn with multiple workers: use one worker or expect to restart
+after changing the schedule so the lock-holding process reloads config).
+"""
+
+import logging
+import os
+
+from apscheduler.schedulers.background import BackgroundScheduler
+
+from app.telestaff.settings_store import get_settings_row
+
+logger = logging.getLogger(__name__)
+
+JOB_ID = "telestaff_roster_fetch"
+_scheduler = None
+_lock_fd = None
+_flask_app = None
+
+
+def _try_acquire_singleton_lock(app):
+    """Return True if this process should run the scheduler (Unix lock)."""
+    global _lock_fd
+    if os.name == "nt":
+        return True
+    try:
+        import fcntl
+    except ImportError:
+        return True
+    os.makedirs(app.instance_path, exist_ok=True)
+    path = os.path.join(app.instance_path, "telestaff_scheduler.lock")
+    fd = os.open(path, os.O_CREAT | os.O_RDWR, 0o644)
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except BlockingIOError:
+        os.close(fd)
+        logger.info(
+            "Telestaff scheduler: another process holds the lock; "
+            "not starting scheduler in this worker."
+        )
+        return False
+    _lock_fd = fd
+    return True
+
+
+def _scheduled_roster_fetch():
+    global _flask_app
+    if _flask_app is None:
+        return
+    with _flask_app.app_context():
+        row = get_settings_row()
+        if row is None or not row.roster_scheduler_enabled:
+            return
+        from app.telestaff.routes import telestaff_roster_payload
+
+        _payload, err = telestaff_roster_payload(date=None)
+        if err is not None:
+            resp, status = err
+            data = resp.get_json(silent=True) or {}
+            msg = data.get("error") or data.get("hint") or str(status)
+            logger.warning("Telestaff scheduled fetch failed: %s", msg)
+        else:
+            logger.info("Telestaff scheduled roster fetch completed.")
+
+
+def reschedule_telestaff_scheduler(app):
+    """Apply interval and enabled flag from DB to APScheduler."""
+    global _scheduler
+    if _scheduler is None:
+        return
+    with app.app_context():
+        row = get_settings_row()
+        enabled = bool(row and row.roster_scheduler_enabled)
+        seconds = (
+            int(row.roster_fetch_interval_seconds)
+            if row and row.roster_fetch_interval_seconds
+            else 900
+        )
+        seconds = max(60, min(86400, seconds))
+
+    try:
+        _scheduler.remove_job(JOB_ID)
+    except Exception:
+        pass
+
+    if not enabled:
+        logger.info("Telestaff scheduler: disabled in DB.")
+        return
+
+    _scheduler.add_job(
+        _scheduled_roster_fetch,
+        "interval",
+        seconds=seconds,
+        id=JOB_ID,
+        replace_existing=True,
+        max_instances=1,
+        coalesce=True,
+    )
+    logger.info(
+        "Telestaff scheduler: job registered every %s seconds.", seconds
+    )
+
+
+def init_telestaff_scheduler(app):
+    """Start background scheduler (call from create_app)."""
+    global _scheduler, _flask_app
+
+    if app.testing:
+        return
+    if app.debug and os.environ.get("WERKZEUG_RUN_MAIN") != "true":
+        return
+
+    if not _try_acquire_singleton_lock(app):
+        return
+
+    _flask_app = app
+    _scheduler = BackgroundScheduler(daemon=True)
+    _scheduler.start()
+    reschedule_telestaff_scheduler(app)

--- a/app/telestaff/settings_store.py
+++ b/app/telestaff/settings_store.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python
+# -*- coding: ascii -*-
+
+"""DB-backed Telestaff URL and cookie header; env (TS_*) is fallback when unset."""
+
+import json
+from datetime import datetime
+
+from app import db
+from app.models import TelestaffSettings
+
+SINGLETON_ID = 1
+
+
+def get_settings_row():
+    """Return the singleton row or None if never created."""
+    return TelestaffSettings.query.get(SINGLETON_ID)
+
+
+def get_or_create_settings_row():
+    row = get_settings_row()
+    if row is None:
+        row = TelestaffSettings(id=SINGLETON_ID)
+        db.session.add(row)
+        db.session.commit()
+    return row
+
+
+def effective_server(app):
+    """Prefer DB `server_url` when set; else `TS_SERVER` from config/env."""
+    row = get_settings_row()
+    if row and row.server_url and str(row.server_url).strip():
+        return str(row.server_url).strip()
+    return (app.config.get("TS_SERVER") or "").strip()
+
+
+def effective_cookie(app):
+    """Prefer DB `cookie_header` when the column was written; else env."""
+    row = get_settings_row()
+    if row is not None and row.cookie_header is not None:
+        return row.cookie_header
+    return app.config.get("TS_COOKIE") or ""
+
+
+def persist_telestaff_cookies(cookie_string):
+    """Save refreshed cookie header from festis after a roster fetch."""
+    row = get_or_create_settings_row()
+    row.cookie_header = cookie_string
+    db.session.commit()
+
+
+def save_admin_settings(server_url, cookie_header):
+    """Save admin form. Empty strings clear DB fields (NULL) so env is used again."""
+    row = get_or_create_settings_row()
+    row.server_url = server_url.strip() if server_url and server_url.strip() else None
+    row.cookie_header = (
+        cookie_header.strip() if cookie_header and cookie_header.strip() else None
+    )
+    row.updated_at = datetime.utcnow()
+    db.session.commit()
+
+
+def save_schedule_settings(enabled, interval_minutes, app):
+    """
+    Enable/disable server-side roster polling and interval (minutes).
+    Persists to DB and reapplies APScheduler when the scheduler is running.
+    """
+    row = get_or_create_settings_row()
+    row.roster_scheduler_enabled = bool(enabled)
+    if interval_minutes is None or interval_minutes < 1:
+        minutes = 15
+    else:
+        minutes = min(1440, int(interval_minutes))
+    row.roster_fetch_interval_seconds = max(60, min(86400, minutes * 60))
+    row.updated_at = datetime.utcnow()
+    db.session.commit()
+    from app.telestaff.scheduler import reschedule_telestaff_scheduler
+
+    reschedule_telestaff_scheduler(app)
+
+
+def persist_last_roster_snapshot(payload_dict):
+    """Store JSON snapshot and fetch time after a successful roster response."""
+    row = get_or_create_settings_row()
+    row.last_roster_fetched_at = datetime.utcnow()
+    row.last_roster_json = json.dumps(payload_dict, default=str)
+    db.session.commit()

--- a/app/templates/admin/admin_base.html
+++ b/app/templates/admin/admin_base.html
@@ -12,6 +12,9 @@
     <a class="nav-link" href="/admin/unitmanager/">Units </a>
 </li>
 <li class="nav-item">
+    <a class="nav-link" href="/admin/telestaff/">Telestaff </a>
+</li>
+<li class="nav-item">
     <a class="nav-link" href="/auth/logout">Logout</a>
 </li>
 {% endblock %}

--- a/app/templates/admin/telestaff_roster_json.html
+++ b/app/templates/admin/telestaff_roster_json.html
@@ -1,0 +1,17 @@
+{% extends "admin/admin_base.html" %}
+{% block title %}Telestaff roster (JSON){% endblock %}
+
+{% block content %}
+	<p>
+		<a href="{{ url_for('admin.telestaff_settings') }}" class="btn btn-outline-secondary btn-sm">&larr; Back to Telestaff settings</a>
+	</p>
+	<h1>Raw roster JSON</h1>
+	{% if last_fetch %}
+	<p class="text-muted small">Snapshot from last fetch: {{ last_fetch }}</p>
+	{% endif %}
+	{% if pretty_json %}
+	<pre class="bg-light border p-3" style="max-height: 80vh; overflow: auto;"><code>{{ pretty_json }}</code></pre>
+	{% else %}
+	<p class="text-muted">No roster snapshot yet. Use &quot;Fetch latest roster&quot; on the Telestaff settings page.</p>
+	{% endif %}
+{% endblock %}

--- a/app/templates/admin/telestaff_settings.html
+++ b/app/templates/admin/telestaff_settings.html
@@ -1,0 +1,80 @@
+{% extends "admin/admin_base.html" %}
+{% block title %}Telestaff{% endblock %}
+
+{% block content %}
+	<h1>Telestaff</h1>
+	<p class="text-muted">
+		Values saved here are stored in the database. Leave a field blank to use
+		<code>TS_SERVER</code> or <code>TS_COOKIE</code> from the environment.
+		After each roster fetch, refreshed cookies are written back to the database.
+	</p>
+
+	<h2 class="h5 mt-4">Roster</h2>
+	<p class="mb-2">
+		{% if row and row.last_roster_fetched_at %}
+		<strong>Last roster fetch:</strong> {{ row.last_roster_fetched_at }}
+		{% else %}
+		<span class="text-muted">No roster has been fetched yet.</span>
+		{% endif %}
+	</p>
+	<form method="post" action="{{ url_for('admin.telestaff_settings') }}" class="form-inline mb-3">
+		<input type="hidden" name="action" value="fetch_roster">
+		<button type="submit" class="btn btn-outline-primary mr-2">Fetch latest roster</button>
+		{% if row and row.last_roster_json %}
+		<a href="{{ url_for('admin.telestaff_roster_json') }}" class="btn btn-outline-secondary">View raw roster JSON</a>
+		{% endif %}
+	</form>
+
+	<h2 class="h5 mt-4">Server schedule</h2>
+	<p class="text-muted small">
+		When enabled, the server fetches the roster on a fixed interval (APScheduler) and stores
+		a snapshot. Station dashboards read <code>/roster/snapshot/</code> so they do not call Telestaff
+		on every browser poll.
+	</p>
+	<form method="post" action="{{ url_for('admin.telestaff_settings') }}" class="mb-4">
+		<input type="hidden" name="action" value="save_schedule">
+		<div class="form-group form-check">
+			<input type="checkbox" class="form-check-input" id="roster_scheduler_enabled"
+				name="roster_scheduler_enabled" {% if row and row.roster_scheduler_enabled %}checked{% endif %}>
+			<label class="form-check-label" for="roster_scheduler_enabled">Enable scheduled roster fetch</label>
+		</div>
+		<div class="form-group">
+			<label for="roster_fetch_interval_minutes">Fetch interval (minutes)</label>
+			<input type="number" class="form-control" style="max-width: 8rem;" min="1" max="1440" step="1"
+				id="roster_fetch_interval_minutes" name="roster_fetch_interval_minutes"
+				value="{{ interval_minutes }}">
+			<small class="form-text text-muted">Between 1 and 1440 (1 day). Default 15.</small>
+		</div>
+		<button type="submit" class="btn btn-primary">Save schedule</button>
+	</form>
+
+	<h2 class="h5 mt-4">Connection</h2>
+	<form method="post" action="{{ url_for('admin.telestaff_settings') }}">
+		<input type="hidden" name="action" value="save">
+		<div class="form-group">
+			<label for="server_url">Telestaff server URL</label>
+			<input type="url" class="form-control" id="server_url" name="server_url"
+				placeholder="https://telestaff.example.gov"
+				value="{{ row.server_url if row and row.server_url else '' }}">
+			<small class="form-text text-muted">
+				Effective URL in use: <strong>{{ effective_server or '(none)' }}</strong>
+				{% if env_server %}
+				| env <code>TS_SERVER</code>: {{ env_server }}
+				{% endif %}
+			</small>
+		</div>
+		<div class="form-group">
+			<label for="cookie_header">Cookie header</label>
+			<textarea class="form-control font-monospace" id="cookie_header" name="cookie_header"
+				rows="4" placeholder="name=value; name2=value2">{{ row.cookie_header if row else '' }}</textarea>
+			<small class="form-text text-muted">
+				Paste the full <code>Cookie</code> header value if required for your Telestaff host.
+				Effective cookie is stored when non-empty in DB; roster responses update this field automatically.
+			</small>
+		</div>
+		{% if row and row.updated_at %}
+		<p class="small text-muted">Settings last saved: {{ row.updated_at }}</p>
+		{% endif %}
+		<button type="submit" class="btn btn-primary">Save</button>
+	</form>
+{% endblock %}

--- a/migrations/versions/a1b2c3d4e5f6_add_telestaff_settings.py
+++ b/migrations/versions/a1b2c3d4e5f6_add_telestaff_settings.py
@@ -1,0 +1,30 @@
+"""add telestaff_settings singleton table
+
+Revision ID: a1b2c3d4e5f6
+Revises: 7f480dbaa883
+Create Date: 2026-04-03
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "a1b2c3d4e5f6"
+down_revision = "7f480dbaa883"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "telestaff_settings",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("server_url", sa.String(length=512), nullable=True),
+        sa.Column("cookie_header", sa.Text(), nullable=True),
+        sa.Column("updated_at", sa.DateTime(), nullable=True),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+
+def downgrade():
+    op.drop_table("telestaff_settings")

--- a/migrations/versions/b2c3d4e5f6a7_telestaff_last_roster_snapshot.py
+++ b/migrations/versions/b2c3d4e5f6a7_telestaff_last_roster_snapshot.py
@@ -1,0 +1,31 @@
+"""telestaff_settings: last roster fetch time and JSON snapshot
+
+Revision ID: b2c3d4e5f6a7
+Revises: a1b2c3d4e5f6
+Create Date: 2026-04-03
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "b2c3d4e5f6a7"
+down_revision = "a1b2c3d4e5f6"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "telestaff_settings",
+        sa.Column("last_roster_fetched_at", sa.DateTime(), nullable=True),
+    )
+    op.add_column(
+        "telestaff_settings",
+        sa.Column("last_roster_json", sa.Text(), nullable=True),
+    )
+
+
+def downgrade():
+    op.drop_column("telestaff_settings", "last_roster_json")
+    op.drop_column("telestaff_settings", "last_roster_fetched_at")

--- a/migrations/versions/c3d4e5f6a7b8_telestaff_roster_scheduler.py
+++ b/migrations/versions/c3d4e5f6a7b8_telestaff_roster_scheduler.py
@@ -1,0 +1,41 @@
+"""telestaff_settings: roster scheduler flags
+
+Revision ID: c3d4e5f6a7b8
+Revises: b2c3d4e5f6a7
+Create Date: 2026-04-03
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "c3d4e5f6a7b8"
+down_revision = "b2c3d4e5f6a7"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "telestaff_settings",
+        sa.Column(
+            "roster_scheduler_enabled",
+            sa.Boolean(),
+            nullable=False,
+            server_default="0",
+        ),
+    )
+    op.add_column(
+        "telestaff_settings",
+        sa.Column(
+            "roster_fetch_interval_seconds",
+            sa.Integer(),
+            nullable=False,
+            server_default="900",
+        ),
+    )
+
+
+def downgrade():
+    op.drop_column("telestaff_settings", "roster_fetch_interval_seconds")
+    op.drop_column("telestaff_settings", "roster_scheduler_enabled")


### PR DESCRIPTION
…ebstaff parsing

- Add TelestaffSettings model (singleton): server URL, cookies, last roster JSON/time, scheduler enable + interval; Alembic migrations for table and columns.
- Add settings_store helpers: effective server/cookie, persist cookies and snapshots, save admin + schedule settings.
- Refactor telestaff_roster_payload(); persist snapshot on every successful /roster; add GET /roster/snapshot for cached JSON (dashboards poll without hitting Telestaff).
- Start APScheduler in create_app (skipped in tests / reloader parent); file lock on Unix for multi-worker; reschedule on schedule save.
- Admin: Telestaff page (connection, manual fetch, schedule, raw JSON view), nav link.
- webstaff.js: use /roster/snapshot/, poll interval 60s; fix roster tree walk for all Institution/Agency/Batallion; shift title matching for legacy "Ops A Shift" and newer "4 Ops Shifts A"; optional shift filter when getShift() is empty; defensive array guards; robust status_code/data checks.
- Fix Unit/TelestaffSettings __repr__ on Unit model.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new DB state, admin-configurable Telestaff connection settings (including cookies), and a background APScheduler job that runs inside the web process; misconfiguration or scheduler behavior could impact roster freshness and production stability.
> 
> **Overview**
> **Telestaff roster fetching is moved to a server-side snapshot model.** The backend now persists the last roster response in the DB and exposes `GET /roster/snapshot/` so dashboards poll cached data instead of hitting Telestaff on every browser refresh.
> 
> **Introduces DB-backed Telestaff configuration and scheduling.** Adds a `TelestaffSettings` singleton table (via Alembic migrations) to store server URL, cookie header, last fetch time/JSON, and scheduler enable/interval; a new admin page can edit these, trigger a manual fetch, and view the raw stored JSON.
> 
> **Adds a background scheduler and client parsing hardening.** `create_app` now starts an APScheduler-based interval fetch (singleton-locked per host process) and `webstaff.js` switches to the snapshot endpoint, increases poll frequency, and improves roster tree traversal/shift-title matching with more defensive null/array checks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 17329f6ecb27331266c57dafc574f11d013a0035. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->